### PR TITLE
feat: Add cooperative management contract tests

### DIFF
--- a/ContractsRevo/cooperative-management-contract/src/lib.rs
+++ b/ContractsRevo/cooperative-management-contract/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use datatype::DataKey;
-use soroban_sdk::{Address, Env, contract, contractimpl};
+use soroban_sdk::{Address, Env, String, contract, contractimpl};
 
 mod datatype;
 mod governance;
@@ -21,75 +21,6 @@ impl CooperativeManagementContract {
             panic!("Contract is already initialized");
         }
         env.storage().persistent().set(&DataKey::Admin, &admin);
-    }
-}
-
-// Implement Membership trait
-impl interface::Membership for CooperativeManagementContract {
-    fn register_member(env: Env, member: Address, name: String) -> Result<(), datatype::CooperativeError> {
-        membership::Membership::register_member(env, member, name)
-    }
-
-    fn verify_member(env: Env, admin: Address, address: Address) -> Result<(), datatype::CooperativeError> {
-        membership::Membership::verify_member(env, admin, address)
-    }
-
-    fn track_contribution(env: Env, address: Address, amount: u32) -> Result<(), datatype::CooperativeError> {
-        membership::Membership::track_contribution(env, address, amount)
-    }
-
-    fn update_reputation(env: Env, admin: Address, address: Address, points: u32) -> Result<(), datatype::CooperativeError> {
-        membership::Membership::update_reputation(env, admin, address, points)
-    }
-}
-
-// Implement ResourceSharing trait
-impl interface::ResourceSharing for CooperativeManagementContract {
-    fn register_resource(env: Env, owner: Address, description: String) -> Result<(), datatype::CooperativeError> {
-        resource_sharing::ResourceSharing::register_resource(env, owner, description)
-    }
-
-    fn get_resources_by_owner(env: Env, owner: Address) -> soroban_sdk::Vec<u32> {
-        resource_sharing::ResourceSharing::get_resources_by_owner(env, owner)
-    }
-
-    fn borrow_resource(env: Env, borrower: Address, owner: Address, counter: u32) -> Result<(), datatype::CooperativeError> {
-        resource_sharing::ResourceSharing::borrow_resource(env, borrower, owner, counter)
-    }
-
-    fn return_resource(env: Env, caller: Address, owner: Address, counter: u32) -> Result<(), datatype::CooperativeError> {
-        resource_sharing::ResourceSharing::return_resource(env, caller, owner, counter)
-    }
-
-    fn schedule_resource(env: Env, owner: Address, counter: u32, borrower: Address, time_slot: String) -> Result<(), datatype::CooperativeError> {
-        resource_sharing::ResourceSharing::schedule_resource(env, owner, counter, borrower, time_slot)
-    }
-
-    fn track_maintenance(env: Env, owner: Address, caller: Address, resource_id: u32, details: String) -> Result<(), datatype::CooperativeError> {
-        resource_sharing::ResourceSharing::track_maintenance(env, owner, caller, resource_id, details)
-    }
-}
-
-// Implement Governance trait
-impl interface::Governance for CooperativeManagementContract {
-    fn submit_proposal(env: Env, proposer: Address, proposal: String) -> Result<(), datatype::CooperativeError> {
-        governance::Governance::submit_proposal(env, proposer, proposal)
-    }
-
-    fn vote_on_proposal(env: Env, voter: Address, proposer: Address, approve: bool) -> Result<(), datatype::CooperativeError> {
-        governance::Governance::vote_on_proposal(env, voter, proposer, approve)
-    }
-
-    fn execute_decision(env: Env, proposer: Address) -> Result<(), datatype::CooperativeError> {
-        governance::Governance::execute_decision(env, proposer)
-    }
-
-    fn trigger_emergency(env: Env, caller: Address, reason: String) -> Result<(), datatype::CooperativeError> {
-        governance::Governance::trigger_emergency(env, caller, reason)
-    }
-
-    fn track_accountability(env: Env, member: Address) -> Result<i128, datatype::CooperativeError> {
-        governance::Governance::track_accountability(env, member)
     }
 }
 

--- a/ContractsRevo/cooperative-management-contract/src/lib.rs
+++ b/ContractsRevo/cooperative-management-contract/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use datatype::DataKey;
-use soroban_sdk::{Address, Env, String, contract, contractimpl};
+use soroban_sdk::{Address, Env, contract, contractimpl};
 
 mod datatype;
 mod governance;
@@ -9,6 +9,7 @@ mod interface;
 mod membership;
 mod profit_distribution;
 mod resource_sharing;
+mod test;
 
 #[contract]
 pub struct CooperativeManagementContract;
@@ -23,6 +24,3 @@ impl CooperativeManagementContract {
         env.storage().persistent().set(&DataKey::Admin, &admin);
     }
 }
-
-#[cfg(test)]
-mod test;

--- a/ContractsRevo/cooperative-management-contract/src/lib.rs
+++ b/ContractsRevo/cooperative-management-contract/src/lib.rs
@@ -23,3 +23,75 @@ impl CooperativeManagementContract {
         env.storage().persistent().set(&DataKey::Admin, &admin);
     }
 }
+
+// Implement Membership trait
+impl interface::Membership for CooperativeManagementContract {
+    fn register_member(env: Env, member: Address, name: String) -> Result<(), datatype::CooperativeError> {
+        membership::Membership::register_member(env, member, name)
+    }
+
+    fn verify_member(env: Env, admin: Address, address: Address) -> Result<(), datatype::CooperativeError> {
+        membership::Membership::verify_member(env, admin, address)
+    }
+
+    fn track_contribution(env: Env, address: Address, amount: u32) -> Result<(), datatype::CooperativeError> {
+        membership::Membership::track_contribution(env, address, amount)
+    }
+
+    fn update_reputation(env: Env, admin: Address, address: Address, points: u32) -> Result<(), datatype::CooperativeError> {
+        membership::Membership::update_reputation(env, admin, address, points)
+    }
+}
+
+// Implement ResourceSharing trait
+impl interface::ResourceSharing for CooperativeManagementContract {
+    fn register_resource(env: Env, owner: Address, description: String) -> Result<(), datatype::CooperativeError> {
+        resource_sharing::ResourceSharing::register_resource(env, owner, description)
+    }
+
+    fn get_resources_by_owner(env: Env, owner: Address) -> soroban_sdk::Vec<u32> {
+        resource_sharing::ResourceSharing::get_resources_by_owner(env, owner)
+    }
+
+    fn borrow_resource(env: Env, borrower: Address, owner: Address, counter: u32) -> Result<(), datatype::CooperativeError> {
+        resource_sharing::ResourceSharing::borrow_resource(env, borrower, owner, counter)
+    }
+
+    fn return_resource(env: Env, caller: Address, owner: Address, counter: u32) -> Result<(), datatype::CooperativeError> {
+        resource_sharing::ResourceSharing::return_resource(env, caller, owner, counter)
+    }
+
+    fn schedule_resource(env: Env, owner: Address, counter: u32, borrower: Address, time_slot: String) -> Result<(), datatype::CooperativeError> {
+        resource_sharing::ResourceSharing::schedule_resource(env, owner, counter, borrower, time_slot)
+    }
+
+    fn track_maintenance(env: Env, owner: Address, caller: Address, resource_id: u32, details: String) -> Result<(), datatype::CooperativeError> {
+        resource_sharing::ResourceSharing::track_maintenance(env, owner, caller, resource_id, details)
+    }
+}
+
+// Implement Governance trait
+impl interface::Governance for CooperativeManagementContract {
+    fn submit_proposal(env: Env, proposer: Address, proposal: String) -> Result<(), datatype::CooperativeError> {
+        governance::Governance::submit_proposal(env, proposer, proposal)
+    }
+
+    fn vote_on_proposal(env: Env, voter: Address, proposer: Address, approve: bool) -> Result<(), datatype::CooperativeError> {
+        governance::Governance::vote_on_proposal(env, voter, proposer, approve)
+    }
+
+    fn execute_decision(env: Env, proposer: Address) -> Result<(), datatype::CooperativeError> {
+        governance::Governance::execute_decision(env, proposer)
+    }
+
+    fn trigger_emergency(env: Env, caller: Address, reason: String) -> Result<(), datatype::CooperativeError> {
+        governance::Governance::trigger_emergency(env, caller, reason)
+    }
+
+    fn track_accountability(env: Env, member: Address) -> Result<i128, datatype::CooperativeError> {
+        governance::Governance::track_accountability(env, member)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/ContractsRevo/cooperative-management-contract/src/test.rs
+++ b/ContractsRevo/cooperative-management-contract/src/test.rs
@@ -1,0 +1,530 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, vec, Env, String};
+
+// Test helper function to create a new environment
+fn setup() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    
+    // Initialize contract with admin
+    let contract = CooperativeManagementContract;
+    contract.init(&env, &admin);
+    
+    (env, admin, member1, member2)
+}
+
+#[test]
+fn test_contract_initialization() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract = CooperativeManagementContract;
+    
+    // Test successful initialization
+    contract.init(&env, &admin);
+    
+    // Test double initialization (should fail)
+    let result = std::panic::catch_unwind(|| {
+        contract.init(&env, &admin);
+    });
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_member_registration_validation() {
+    let (env, admin, member1, _) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Test successful registration with valid data
+    assert!(contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).is_ok());
+    
+    // Test registration with empty name
+    let empty_name = String::from_str(&env, "");
+    assert!(contract.register_member(&env, &member1, empty_name).is_err());
+    
+    // Test duplicate registration
+    assert!(contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).is_err());
+}
+
+#[test]
+fn test_member_verification_authorization() {
+    let (env, admin, member1, _) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register member
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    
+    // Test verification by admin (should succeed)
+    assert!(contract.verify_member(&env, &admin, &member1).is_ok());
+    
+    // Test verification by non-admin (should fail)
+    let non_admin = Address::generate(&env);
+    assert!(contract.verify_member(&env, &non_admin, &member1).is_err());
+    
+    // Test verification of non-existent member
+    let non_existent = Address::generate(&env);
+    assert!(contract.verify_member(&env, &admin, &non_existent).is_err());
+}
+
+#[test]
+fn test_membership_levels() {
+    let (env, admin, member1, _) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register member
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    
+    // Verify member (basic level)
+    assert!(contract.verify_member(&env, &admin, &member1).is_ok());
+    
+    // Track contributions to increase level
+    assert!(contract.track_contribution(&env, &member1, 100).is_ok());
+    
+    // Update reputation to reflect higher level
+    assert!(contract.update_reputation(&env, &admin, &member1, 10).is_ok());
+    
+    // Check accountability reflects the new level
+    let reputation = contract.track_accountability(&env, &member1).unwrap();
+    assert!(reputation > 0);
+}
+
+#[test]
+fn test_resource_sharing_validation() {
+    let (env, admin, member1, member2) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register members
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_member(&env, &member2, String::from_str(&env, "Member 2")).unwrap();
+    
+    // Test resource registration
+    assert!(contract.register_resource(
+        &env,
+        &member1,
+        String::from_str(&env, "Tractor")
+    ).is_ok());
+    
+    // Test resource registration with empty description
+    assert!(contract.register_resource(
+        &env,
+        &member1,
+        String::from_str(&env, "")
+    ).is_err());
+    
+    // Test borrowing by non-member
+    let non_member = Address::generate(&env);
+    assert!(contract.borrow_resource(&env, &non_member, &member1, 1).is_err());
+    
+    // Test borrowing already borrowed resource
+    assert!(contract.borrow_resource(&env, &member2, &member1, 1).is_ok());
+    assert!(contract.borrow_resource(&env, &member2, &member1, 1).is_err());
+}
+
+#[test]
+fn test_resource_scheduling_conflicts() {
+    let (env, admin, member1, member2) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register members
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_member(&env, &member2, String::from_str(&env, "Member 2")).unwrap();
+    
+    // Register resource
+    assert!(contract.register_resource(
+        &env,
+        &member1,
+        String::from_str(&env, "Tractor")
+    ).is_ok());
+    
+    // Schedule resource for member2
+    assert!(contract.schedule_resource(
+        &env,
+        &member1,
+        1,
+        &member2,
+        String::from_str(&env, "2024-03-20 10:00")
+    ).is_ok());
+    
+    // Try to schedule the same time slot (should fail)
+    let member3 = Address::generate(&env);
+    contract.register_member(&env, &member3, String::from_str(&env, "Member 3")).unwrap();
+    assert!(contract.schedule_resource(
+        &env,
+        &member1,
+        1,
+        &member3,
+        String::from_str(&env, "2024-03-20 10:00")
+    ).is_err());
+    
+    // Schedule a different time slot (should succeed)
+    assert!(contract.schedule_resource(
+        &env,
+        &member1,
+        1,
+        &member3,
+        String::from_str(&env, "2024-03-20 14:00")
+    ).is_ok());
+}
+
+#[test]
+fn test_equitable_resource_distribution() {
+    let (env, admin, member1, member2) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register members
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_member(&env, &member2, String::from_str(&env, "Member 2")).unwrap();
+    
+    // Register multiple resources
+    assert!(contract.register_resource(
+        &env,
+        &member1,
+        String::from_str(&env, "Tractor")
+    ).is_ok());
+    
+    assert!(contract.register_resource(
+        &env,
+        &member1,
+        String::from_str(&env, "Harvester")
+    ).is_ok());
+    
+    // Get resources by owner
+    let resources = contract.get_resources_by_owner(&env, &member1);
+    assert_eq!(resources.len(), 2);
+    
+    // Borrow resources by different members
+    assert!(contract.borrow_resource(&env, &member2, &member1, 1).is_ok());
+    
+    // Verify resource is no longer available
+    let non_member = Address::generate(&env);
+    assert!(contract.borrow_resource(&env, &non_member, &member1, 1).is_err());
+    
+    // Return resource
+    assert!(contract.return_resource(&env, &member2, &member1, 1).is_ok());
+    
+    // Verify resource is available again
+    assert!(contract.borrow_resource(&env, &non_member, &member1, 1).is_ok());
+}
+
+#[test]
+fn test_shared_transportation_coordination() {
+    let (env, admin, member1, member2) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register members
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_member(&env, &member2, String::from_str(&env, "Member 2")).unwrap();
+    
+    // Register transportation resource
+    assert!(contract.register_resource(
+        &env,
+        &member1,
+        String::from_str(&env, "Transport Truck")
+    ).is_ok());
+    
+    // Schedule transportation for member2
+    assert!(contract.schedule_resource(
+        &env,
+        &member1,
+        1,
+        &member2,
+        String::from_str(&env, "2024-03-20 10:00")
+    ).is_ok());
+    
+    // Verify transportation is scheduled
+    let resources = contract.get_resources_by_owner(&env, &member1);
+    assert_eq!(resources.len(), 1);
+    
+    // Track maintenance for transportation
+    assert!(contract.track_maintenance(
+        &env,
+        &member1,
+        &member1,
+        1,
+        String::from_str(&env, "Regular maintenance for transport truck")
+    ).is_ok());
+}
+
+#[test]
+fn test_governance_validation() {
+    let (env, admin, member1, member2) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register members
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_member(&env, &member2, String::from_str(&env, "Member 2")).unwrap();
+    
+    // Test proposal submission by non-member
+    let non_member = Address::generate(&env);
+    assert!(contract.submit_proposal(
+        &env,
+        &non_member,
+        String::from_str(&env, "Invalid proposal")
+    ).is_err());
+    
+    // Test valid proposal submission
+    assert!(contract.submit_proposal(
+        &env,
+        &member1,
+        String::from_str(&env, "Valid proposal")
+    ).is_ok());
+    
+    // Test voting by non-member
+    assert!(contract.vote_on_proposal(&env, &non_member, &member1, true).is_err());
+    
+    // Test voting on non-existent proposal
+    assert!(contract.vote_on_proposal(&env, &member2, &non_member, true).is_err());
+}
+
+#[test]
+fn test_voting_mechanism_integrity() {
+    let (env, admin, member1, member2) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register members
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_member(&env, &member2, String::from_str(&env, "Member 2")).unwrap();
+    
+    // Submit proposal
+    assert!(contract.submit_proposal(
+        &env,
+        &member1,
+        String::from_str(&env, "New resource acquisition")
+    ).is_ok());
+    
+    // Vote for proposal
+    assert!(contract.vote_on_proposal(&env, &member2, &member1, true).is_ok());
+    
+    // Try to vote again (should fail)
+    assert!(contract.vote_on_proposal(&env, &member2, &member1, false).is_err());
+    
+    // Execute decision
+    assert!(contract.execute_decision(&env, &member1).is_ok());
+    
+    // Try to execute again (should fail)
+    assert!(contract.execute_decision(&env, &member1).is_err());
+}
+
+#[test]
+fn test_decision_execution_logic() {
+    let (env, admin, member1, member2) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register members
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_member(&env, &member2, String::from_str(&env, "Member 2")).unwrap();
+    
+    // Submit proposal
+    assert!(contract.submit_proposal(
+        &env,
+        &member1,
+        String::from_str(&env, "New resource acquisition")
+    ).is_ok());
+    
+    // Vote against proposal
+    assert!(contract.vote_on_proposal(&env, &member2, &member1, false).is_ok());
+    
+    // Try to execute decision (should fail due to negative votes)
+    assert!(contract.execute_decision(&env, &member1).is_err());
+    
+    // Submit new proposal
+    assert!(contract.submit_proposal(
+        &env,
+        &member1,
+        String::from_str(&env, "Another proposal")
+    ).is_ok());
+    
+    // Vote for proposal
+    assert!(contract.vote_on_proposal(&env, &member2, &member1, true).is_ok());
+    
+    // Execute decision (should succeed)
+    assert!(contract.execute_decision(&env, &member1).is_ok());
+}
+
+#[test]
+fn test_emergency_protocol_authorization() {
+    let (env, admin, member1, _) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Test emergency trigger by non-admin
+    assert!(contract.trigger_emergency(
+        &env,
+        &member1,
+        String::from_str(&env, "Unauthorized emergency")
+    ).is_err());
+    
+    // Test emergency trigger by admin
+    assert!(contract.trigger_emergency(
+        &env,
+        &admin,
+        String::from_str(&env, "Authorized emergency")
+    ).is_ok());
+}
+
+#[test]
+fn test_maintenance_logging_validation() {
+    let (env, admin, member1, _) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register member and resource
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_resource(
+        &env,
+        &member1,
+        String::from_str(&env, "Tractor")
+    ).unwrap();
+    
+    // Test maintenance logging by owner
+    assert!(contract.track_maintenance(
+        &env,
+        &member1,
+        &member1,
+        1,
+        String::from_str(&env, "Valid maintenance log")
+    ).is_ok());
+    
+    // Test maintenance logging by non-owner
+    let non_owner = Address::generate(&env);
+    assert!(contract.track_maintenance(
+        &env,
+        &member1,
+        &non_owner,
+        1,
+        String::from_str(&env, "Invalid maintenance log")
+    ).is_err());
+    
+    // Test maintenance logging for non-existent resource
+    assert!(contract.track_maintenance(
+        &env,
+        &member1,
+        &member1,
+        999,
+        String::from_str(&env, "Invalid resource ID")
+    ).is_err());
+}
+
+#[test]
+fn test_reputation_and_contribution_validation() {
+    let (env, admin, member1, _) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register member
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    
+    // Test contribution tracking for non-member
+    let non_member = Address::generate(&env);
+    assert!(contract.track_contribution(&env, &non_member, 100).is_err());
+    
+    // Test valid contribution tracking
+    assert!(contract.track_contribution(&env, &member1, 100).is_ok());
+    
+    // Test reputation update by non-admin
+    assert!(contract.update_reputation(&env, &member1, &member1, 10).is_err());
+    
+    // Test valid reputation update
+    assert!(contract.update_reputation(&env, &admin, &member1, 10).is_ok());
+    
+    // Test reputation update for non-existent member
+    assert!(contract.update_reputation(&env, &admin, &non_member, 10).is_err());
+}
+
+#[test]
+fn test_decision_traceability() {
+    let (env, admin, member1, member2) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register members
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_member(&env, &member2, String::from_str(&env, "Member 2")).unwrap();
+    
+    // Submit proposal
+    assert!(contract.submit_proposal(
+        &env,
+        &member1,
+        String::from_str(&env, "New resource acquisition")
+    ).is_ok());
+    
+    // Vote for proposal
+    assert!(contract.vote_on_proposal(&env, &member2, &member1, true).is_ok());
+    
+    // Execute decision
+    assert!(contract.execute_decision(&env, &member1).is_ok());
+    
+    // Track accountability for both members
+    let member1_accountability = contract.track_accountability(&env, &member1).unwrap();
+    let member2_accountability = contract.track_accountability(&env, &member2).unwrap();
+    
+    // Verify accountability reflects participation
+    assert!(member1_accountability >= 0);
+    assert!(member2_accountability >= 0);
+}
+
+#[test]
+fn test_governance_disputes() {
+    let (env, admin, member1, member2) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register members
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_member(&env, &member2, String::from_str(&env, "Member 2")).unwrap();
+    
+    // Submit proposal
+    assert!(contract.submit_proposal(
+        &env,
+        &member1,
+        String::from_str(&env, "Controversial proposal")
+    ).is_ok());
+    
+    // Vote against proposal
+    assert!(contract.vote_on_proposal(&env, &member2, &member1, false).is_ok());
+    
+    // Try to execute decision (should fail due to tie)
+    assert!(contract.execute_decision(&env, &member1).is_err());
+    
+    // Trigger emergency to resolve dispute
+    assert!(contract.trigger_emergency(
+        &env,
+        &admin,
+        String::from_str(&env, "Resolving governance dispute")
+    ).is_ok());
+}
+
+#[test]
+fn test_cooperative_participation_metrics() {
+    let (env, admin, member1, member2) = setup();
+    let contract = CooperativeManagementContract;
+    
+    // Register members
+    contract.register_member(&env, &member1, String::from_str(&env, "Member 1")).unwrap();
+    contract.register_member(&env, &member2, String::from_str(&env, "Member 2")).unwrap();
+    
+    // Track contributions
+    assert!(contract.track_contribution(&env, &member1, 100).is_ok());
+    assert!(contract.track_contribution(&env, &member2, 50).is_ok());
+    
+    // Update reputation
+    assert!(contract.update_reputation(&env, &admin, &member1, 10).is_ok());
+    assert!(contract.update_reputation(&env, &admin, &member2, 5).is_ok());
+    
+    // Submit and vote on proposals
+    assert!(contract.submit_proposal(
+        &env,
+        &member1,
+        String::from_str(&env, "Proposal 1")
+    ).is_ok());
+    
+    assert!(contract.vote_on_proposal(&env, &member2, &member1, true).is_ok());
+    
+    // Execute decision
+    assert!(contract.execute_decision(&env, &member1).is_ok());
+    
+    // Check accountability metrics
+    let member1_accountability = contract.track_accountability(&env, &member1).unwrap();
+    let member2_accountability = contract.track_accountability(&env, &member2).unwrap();
+    
+    // Verify metrics reflect participation
+    assert!(member1_accountability > member2_accountability);
+} 


### PR DESCRIPTION
# 🌾 Revolutionary Farmers Pull Request 🚜

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [x] Closes #66 
- [x] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [x] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description
- Added test helper setup function
- Implemented membership validation tests
- Added resource sharing and scheduling tests
- Created governance and voting mechanism tests
- Implemented maintenance logging tests
- Added participation metrics tracking tests

---

## 📸 Evidence (A photo is required as evidence)

![image](https://github.com/user-attachments/assets/a3759742-af6b-4814-a145-3e80af827600)


---

## ⏰ Time spent breakdown

2 days

---

## 🌌 Comments

Implementation of comprehensive test suite for the Cooperative Management Contract, ensuring integrity in member registration, resource sharing, and governance processes.

---

Thank you for contributing to Revolutionary Farmers, we are glad that you have chosen us as your project of choice and we hope that you continue to contribute to this great project, so that together we can make our mark at the top!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced comprehensive membership management, resource sharing, and governance functionalities, including member registration, resource scheduling, proposal submission, voting, and emergency protocols.
- **Tests**
	- Added extensive tests covering membership, resource sharing, governance operations, authorization checks, and validation of contract behavior to ensure reliability and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->