### PR TITLE
feat(scripts): add agricultural training contract deployment script

### DIFF
--- a/scripts/deploy_agricultural_training.zsh
+++ b/scripts/deploy_agricultural_training.zsh
@@ -1,0 +1,394 @@
+#!/bin/zsh
+
+# Agricultural Training Contract Deployment Script
+# Usage: ./deploy_agricultural_training.zsh [network] [profile]
+# Example: ./deploy_agricultural_training.zsh testnet default
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Configuration
+CONTRACT_NAME="agricultural-training-contract"
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+CONTRACT_DIR="${PROJECT_ROOT}/ContractsRevo/agricultural-training-contract"
+# Prefer modern Stellar CLI output location; fallback handled in build step
+WASM_PATH="${PROJECT_ROOT}/target/wasm32v1-none/release/agricultural_training_contract.wasm"
+LOG_DIR="${CONTRACT_DIR}/logs"
+DEPLOYMENT_LOG="${LOG_DIR}/deployment_$(date +%Y%m%d_%H%M%S).log"
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1" | tee -a "$DEPLOYMENT_LOG"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1" | tee -a "$DEPLOYMENT_LOG"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1" | tee -a "$DEPLOYMENT_LOG"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1" | tee -a "$DEPLOYMENT_LOG"
+}
+
+print_header() {
+    echo -e "${CYAN}================================${NC}" | tee -a "$DEPLOYMENT_LOG"
+    echo -e "${CYAN}$1${NC}" | tee -a "$DEPLOYMENT_LOG"
+    echo -e "${CYAN}================================${NC}" | tee -a "$DEPLOYMENT_LOG"
+}
+
+# Function to log with timestamp
+log_with_timestamp() {
+    echo "[$(date -u +"%Y-%m-%d %H:%M:%S UTC")] $1" | tee -a "$DEPLOYMENT_LOG"
+}
+
+# Check if required tools are installed
+check_prerequisites() {
+    print_status "Checking prerequisites..."
+
+    # Check for stellar CLI
+    if ! command -v stellar &> /dev/null; then
+        print_error "Stellar CLI is not installed. Please install it first:"
+        echo "cargo install stellar-cli"
+        exit 1
+    fi
+
+    # Check for jq
+    if ! command -v jq &> /dev/null; then
+        print_error "jq is not installed. Please install it first:"
+        echo "brew install jq  # macOS"
+        echo "apt-get install jq  # Ubuntu/Debian"
+        echo "choco install jq  # Windows (Chocolatey)"
+        exit 1
+    fi
+
+    # Check for cargo
+    if ! command -v cargo &> /dev/null; then
+        print_error "Cargo is not installed. Please install Rust first."
+        echo "https://rustup.rs/"
+        exit 1
+    fi
+
+    print_success "Prerequisites check passed"
+}
+
+# Validate parameters
+validate_parameters() {
+    local network="$1"
+    local profile="$2"
+
+    # Validate network parameter
+    if [[ -z "$network" ]]; then
+        print_error "Network parameter is required"
+        print_usage
+        exit 1
+    fi
+
+    if [[ "$network" != "testnet" && "$network" != "mainnet" ]]; then
+        print_error "Invalid network: $network. Must be 'testnet' or 'mainnet'"
+        print_usage
+        exit 1
+    fi
+
+    # Set default profile if not provided
+    if [[ -z "$profile" ]]; then
+        profile="default"
+        print_warning "No profile specified, using default profile"
+    fi
+
+    # Validate profile exists (identity)
+    if ! stellar keys ls 2>&1 | grep -q "$profile"; then
+        print_error "Identity '$profile' does not exist or is not configured"
+        echo "Available identities:"
+        stellar keys ls
+        exit 1
+    fi
+
+    print_success "Parameters validated: network=$network, profile=$profile"
+}
+
+# Setup logging directory
+setup_logging() {
+    mkdir -p "$LOG_DIR"
+    print_status "Logging to: $DEPLOYMENT_LOG"
+
+    # Initialize log file
+    echo "Agricultural Training Contract Deployment Log" > "$DEPLOYMENT_LOG"
+    echo "Started at: $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> "$DEPLOYMENT_LOG"
+    echo "Network: $NETWORK" >> "$DEPLOYMENT_LOG"
+    echo "Profile: $PROFILE" >> "$DEPLOYMENT_LOG"
+    echo "========================================" >> "$DEPLOYMENT_LOG"
+}
+
+# Build the contract
+build_contract() {
+    print_header "BUILDING CONTRACT"
+
+    cd "$CONTRACT_DIR"
+
+    print_status "Building contract with profile: $PROFILE"
+    log_with_timestamp "Starting contract build"
+
+    # Build using stellar contract build
+    if ! stellar contract build --profile "$PROFILE" 2>&1 | tee -a "$DEPLOYMENT_LOG"; then
+        print_error "Contract build failed"
+        log_with_timestamp "Contract build failed"
+        exit 1
+    fi
+
+    # Verify WASM file exists (modern path first)
+    if [[ ! -f "$WASM_PATH" ]]; then
+        # Try alternate path for older CLI versions (per-contract target directory)
+        local ALT_WASM_PATH="${CONTRACT_DIR}/target/wasm32-unknown-unknown/release/agricultural_training_contract.wasm"
+        if [[ -f "$ALT_WASM_PATH" ]]; then
+            WASM_PATH="$ALT_WASM_PATH"
+            print_status "Using WASM from alternate location: $WASM_PATH"
+        else
+            print_error "WASM file not found at expected paths"
+            print_status "Searched locations:"
+            echo "  - ${PROJECT_ROOT}/target/wasm32v1-none/release/agricultural_training_contract.wasm" | tee -a "$DEPLOYMENT_LOG"
+            echo "  - ${CONTRACT_DIR}/target/wasm32-unknown-unknown/release/agricultural_training_contract.wasm" | tee -a "$DEPLOYMENT_LOG"
+            print_status "Available WASM files:"
+            find "$PROJECT_ROOT/target" -name "*.wasm" 2>/dev/null | head -10 | tee -a "$DEPLOYMENT_LOG" || true
+            exit 1
+        fi
+    fi
+
+    local wasm_size=$(ls -lh "$WASM_PATH" | awk '{print $5}')
+    print_success "Contract built successfully"
+    print_status "WASM file: $WASM_PATH"
+    print_status "WASM size: $wasm_size"
+    log_with_timestamp "Contract build completed successfully"
+}
+
+# Upload the contract
+upload_contract() {
+    print_header "UPLOADING CONTRACT"
+
+    print_status "Uploading contract to $NETWORK network"
+    log_with_timestamp "Starting contract upload"
+
+    # Upload the contract and capture JSON output
+    local upload_output
+    if ! upload_output=$(stellar contract upload --network "$NETWORK" --wasm "$WASM_PATH" --json 2>&1); then
+        print_error "Contract upload failed"
+        echo "$upload_output" | tee -a "$DEPLOYMENT_LOG"
+        log_with_timestamp "Contract upload failed"
+        exit 1
+    fi
+
+    # Parse WASM hash from JSON output
+    WASM_HASH=$(echo "$upload_output" | jq -r '.wasm_hash // empty')
+
+    if [[ -z "$WASM_HASH" || "$WASM_HASH" == "null" ]]; then
+        print_error "Failed to extract WASM hash from upload output"
+        echo "Upload output: $upload_output" | tee -a "$DEPLOYMENT_LOG"
+        log_with_timestamp "Failed to extract WASM hash"
+        exit 1
+    fi
+
+    print_success "Contract uploaded successfully"
+    print_status "WASM Hash: $WASM_HASH"
+    log_with_timestamp "Contract upload completed - WASM Hash: $WASM_HASH"
+
+    # Save upload output to log
+    echo "Upload Output:" >> "$DEPLOYMENT_LOG"
+    echo "$upload_output" >> "$DEPLOYMENT_LOG"
+    echo "" >> "$DEPLOYMENT_LOG"
+}
+
+# Deploy the contract
+deploy_contract() {
+    print_header "DEPLOYING CONTRACT"
+
+    print_status "Deploying contract to $NETWORK network"
+    log_with_timestamp "Starting contract deployment"
+
+    # Deploy the contract and capture JSON output
+    local deploy_output
+    if ! deploy_output=$(stellar contract deploy --network "$NETWORK" --wasm-hash "$WASM_HASH" --json 2>&1); then
+        print_error "Contract deployment failed"
+        echo "$deploy_output" | tee -a "$DEPLOYMENT_LOG"
+        log_with_timestamp "Contract deployment failed"
+        exit 1
+    fi
+
+    # Parse contract ID from JSON output
+    CONTRACT_ID=$(echo "$deploy_output" | jq -r '.contract_id // empty')
+
+    if [[ -z "$CONTRACT_ID" || "$CONTRACT_ID" == "null" ]]; then
+        print_error "Failed to extract contract ID from deployment output"
+        echo "Deployment output: $deploy_output" | tee -a "$DEPLOYMENT_LOG"
+        log_with_timestamp "Failed to extract contract ID"
+        exit 1
+    fi
+
+    print_success "Contract deployed successfully"
+    print_status "Contract ID: $CONTRACT_ID"
+    log_with_timestamp "Contract deployment completed - Contract ID: $CONTRACT_ID"
+
+    # Save deployment output to log
+    echo "Deployment Output:" >> "$DEPLOYMENT_LOG"
+    echo "$deploy_output" >> "$DEPLOYMENT_LOG"
+    echo "" >> "$DEPLOYMENT_LOG"
+}
+
+# Save deployment results
+save_deployment_results() {
+    print_header "SAVING DEPLOYMENT RESULTS"
+
+    local results_file="${LOG_DIR}/deployment_results.json"
+    local timestamp=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+    # Create JSON results file
+    cat > "$results_file" << EOF
+{
+  "contract_name": "$CONTRACT_NAME",
+  "network": "$NETWORK",
+  "profile": "$PROFILE",
+  "wasm_hash": "$WASM_HASH",
+  "contract_id": "$CONTRACT_ID",
+  "deployment_timestamp": "$timestamp",
+  "wasm_path": "$WASM_PATH",
+  "deployment_log": "$DEPLOYMENT_LOG"
+}
+EOF
+
+    print_success "Deployment results saved to: $results_file"
+
+    # Also save a simple summary file
+    local summary_file="${LOG_DIR}/latest_deployment.txt"
+    cat > "$summary_file" << EOF
+Agricultural Training Contract Deployment Summary
+=================================================
+Contract: $CONTRACT_NAME
+Network: $NETWORK
+Profile: $PROFILE
+WASM Hash: $WASM_HASH
+Contract ID: $CONTRACT_ID
+Deployed: $timestamp
+Log File: $DEPLOYMENT_LOG
+EOF
+
+    print_success "Deployment summary saved to: $summary_file"
+    log_with_timestamp "Deployment results saved"
+}
+
+# Display final results
+display_results() {
+    print_header "DEPLOYMENT COMPLETED"
+
+    echo -e "${GREEN}✅ Contract deployed successfully!${NC}"
+    echo ""
+    echo -e "${CYAN}Deployment Details:${NC}"
+    echo "  Contract: $CONTRACT_NAME"
+    echo "  Network: $NETWORK"
+    echo "  Profile: $PROFILE"
+    echo "  WASM Hash: $WASM_HASH"
+    echo "  Contract ID: $CONTRACT_ID"
+    echo ""
+    echo -e "${CYAN}Files Created:${NC}"
+    echo "  Deployment Log: $DEPLOYMENT_LOG"
+    echo "  Results JSON: ${LOG_DIR}/deployment_results.json"
+    echo "  Summary: ${LOG_DIR}/latest_deployment.txt"
+    echo ""
+    echo -e "${YELLOW}Next Steps:${NC}"
+    echo "  1. Verify deployment on Stellar Explorer"
+    echo "  2. Test contract functionality"
+    echo "  3. Initialize contract if required"
+    echo ""
+
+    # Network-specific instructions
+    if [[ "$NETWORK" == "testnet" ]]; then
+        echo -e "${BLUE}Testnet Explorer:${NC} https://testnet.stellar.org/explorer"
+    else
+        echo -e "${BLUE}Mainnet Explorer:${NC} https://stellar.org/explorer"
+    fi
+
+    log_with_timestamp "Deployment process completed successfully"
+}
+
+# Print usage information
+print_usage() {
+    echo "Usage: ./deploy_agricultural_training.zsh [network] [profile]"
+    echo ""
+    echo "Arguments:"
+    echo "  network    - Target network (testnet or mainnet)"
+    echo "  profile    - Stellar identity/key to use (optional, defaults to 'default')"
+    echo ""
+    echo "Examples:"
+    echo "  ./deploy_agricultural_training.zsh testnet                    # Deploy to testnet with default identity"
+    echo "  ./deploy_agricultural_training.zsh testnet alice              # Deploy to testnet with 'alice' identity"
+    echo "  ./deploy_agricultural_training.zsh mainnet production         # Deploy to mainnet with production identity"
+    echo ""
+    echo "Prerequisites:"
+    echo "  - Stellar CLI installed (cargo install stellar-cli)"
+    echo "  - jq installed (apt/brew/choco)"
+    echo "  - Valid Stellar identity configured (stellar keys generate <name> --network <network>)"
+    echo ""
+    echo "Setup Identity:"
+    echo "  stellar keys generate <identity_name> --network testnet"
+    echo "  stellar keys fund <identity_name> --network testnet   # Fund testnet account"
+    echo ""
+    echo "The script will:"
+    echo "  1. Build the agricultural training contract"
+    echo "  2. Upload the WASM to the specified network"
+    echo "  3. Deploy the contract and capture the contract ID"
+    echo "  4. Save deployment logs and results"
+}
+
+# Cleanup function
+cleanup() {
+    local exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        print_error "Deployment failed with exit code: $exit_code"
+        log_with_timestamp "Deployment failed with exit code: $exit_code"
+    fi
+    exit $exit_code
+}
+
+# Set up error handling
+trap cleanup EXIT
+
+# Main function
+main() {
+    local network="$1"
+    local profile="$2"
+
+    # Check if help is requested
+    if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+        print_usage
+        exit 0
+    fi
+
+    # Initialize logging
+    setup_logging
+
+    # Validate prerequisites and parameters
+    check_prerequisites
+    validate_parameters "$network" "$profile"
+
+    # Set global variables
+    NETWORK="$network"
+    PROFILE="$profile"
+
+    # Execute deployment steps
+    build_contract
+    upload_contract
+    deploy_contract
+    save_deployment_results
+    display_results
+}
+
+# Run main function with all arguments
+main "$@"


### PR DESCRIPTION
# 🌾 Revolutionary Farmers Pull Request 🚜

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [ ] Closes #229
- [ ] Added tests (if necessary)
- [ ] Run tests
- [ ] Run formatting
- [ ] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

Add an automated deployment script for the `agricultural-training-contract` targeting Stellar Testnet/Mainnet.

Key features:
- Build the contract using `stellar contract build --profile <profile>`
- Upload WASM using `stellar contract upload --network <network> --wasm <path> --json` and parse `wasm_hash`
- Deploy using `stellar contract deploy --network <network> --wasm-hash <hash> --json` and parse `contract_id`
- Network selection support: `testnet` or `mainnet`
- Identity/profile validation via `stellar keys ls`
- Robust error handling and colorized output
- Logs saved to `ContractsRevo/agricultural-training-contract/logs/`:
  - `deployment_YYYYMMDD_HHMMSS.log`
  - `deployment_results.json`
  - `latest_deployment.txt`

Script path:
- `scripts/deploy_agricultural_training.zsh`

Usage:
- `./scripts/deploy_agricultural_training.zsh [network] [profile]`
- Example: `./scripts/deploy_agricultural_training.zsh testnet default`

Prerequisites:
- `cargo install stellar-cli`
- `jq` installed
- Rust & Cargo installed
- A funded testnet identity: `stellar keys generate default --network testnet` and `stellar keys fund default --network testnet`

---

## 📸 Evidence (A photo is required as evidence)

Please replace the placeholder below with a screenshot of a successful deployment output (showing `wasm_hash` and `contract_id`), or a screenshot of `latest_deployment.txt` and `deployment_results.json` contents.

![Deployment Evidence Placeholder](docs/images/agricultural-training-deploy-evidence.png)

Additional textual evidence:
- Summary: `ContractsRevo/agricultural-training-contract/logs/latest_deployment.txt`
- JSON: `ContractsRevo/agricultural-training-contract/logs/deployment_results.json`
- Log: `ContractsRevo/agricultural-training-contract/logs/deployment_YYYYMMDD_HHMMSS.log`

---

## ⏰ Time spent breakdown

- Review existing deploy script conventions: 20 min
- Implement script (build, upload, deploy, logging): 40 min
- Test on local environment and adjust paths: 20 min
- Documentation and PR write-up: 15 min

Total: ~1 hour 35 minutes

---

## 🌌 Comments

- The script aligns with conventions used by other deployment scripts in `scripts/` for consistency.
- It supports both modern `wasm32v1-none` build output and fallback to `wasm32-unknown-unknown` to accommodate different Stellar CLI versions.
- For CI usage, the script’s JSON output (`deployment_results.json`) provides machine-readable deployment metadata.
- Before mainnet usage, ensure the identity has sufficient XLM and that the contract is validated on testnet.

---

Thank you for contributing to Revolutionary Farmers; we are glad that you have chosen us as your project of choice and we hope that you continue to contribute to this great project, so that together we can make our mark at the top!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone Zsh deployment script for the Agricultural Training Contract.
  * Provides a guided flow: prerequisite checks, parameter validation, build, upload, and deploy.
  * Delivers structured, colorized logging with proactive error handling and clear guidance.
  * Saves deployment results to JSON and a human-readable summary, including network, profile, hashes, contract ID, timestamps, and file paths.
  * Displays a final summary with direct explorer links for testnet/mainnet and next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->